### PR TITLE
Fix lighthouse CI GitHub Action

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -19,8 +19,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
Remove `version: 9` from pnpm/action-setup to resolve version conflict with package.json's `packageManager: "pnpm@9.5.0"` field.

## Changes
- Remove `version: 9` from `.github/workflows/lighthouse.yml`

Fixes #54