### PR TITLE
fix: remove non-functional '+' button from expenses list (#45)

### DIFF
--- a/app/components/expenses/ExpenseHeader.vue
+++ b/app/components/expenses/ExpenseHeader.vue
@@ -14,7 +14,6 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (e: 'update:sortOption', value: any): void
-  (e: 'add'): void
   (e: 'toggle-all'): void
 }>()
 
@@ -95,9 +94,6 @@ const displaySortLabel = computed(() => {
           </template>
         </UButton>
       </UDropdownMenu>
-
-      <!-- Add Button -->
-      <slot name="add-button" />
     </div>
   </header>
 </template>

--- a/app/pages/expenses.vue
+++ b/app/pages/expenses.vue
@@ -255,13 +255,7 @@ function selectAllDuplicates() {
         :is-selection-mode="isSelectionMode"
         @update:sort-option="val => sortOption = val"
         @toggle-all="toggleAll"
-      >
-        <template #add-button>
-          <div class="w-8 h-8 rounded-full bg-primary-100 flex items-center justify-center text-primary-600 hover:bg-primary-200 transition-colors">
-            <UIcon name="i-heroicons-plus" class="w-5 h-5" />
-          </div>
-        </template>
-      </ExpensesExpenseHeader>
+      />
 
       <!-- Loading State -->
       <div v-if="isLoading && (expenses?.length || 0) === 0" class="p-8 text-center">


### PR DESCRIPTION
## Summary
Remove the non-functional '+' button from the expenses list header.

## Files Changed
- `app/components/expenses/ExpenseHeader.vue` - removed + button
- `app/pages/expenses.vue` - updates to work without + button