### PR TITLE
fix: pnpm version conflict in GitHub Actions (#54)

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -19,8 +19,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
Fix pnpm version conflict in GitHub Actions Lighthouse workflow.

## Files Changed
- `.github/workflows/lighthouse.yml` - pnpm version fix