### PR TITLE
Epic #90: The performance page is not in the desktop sidebar or in the menu

### DIFF
--- a/app/composables/useNavigation.ts
+++ b/app/composables/useNavigation.ts
@@ -24,6 +24,7 @@ export function useNavigation() {
   ]
 
   const strategyItems: SubMenuItem[] = [
+    { label: 'Performance', to: '/menu/performance', icon: 'i-heroicons-presentation-chart-bar', description: 'LCP, load times, cache hits', color: 'bg-rose-500' },
     { label: 'House Goal', to: '/goal', icon: 'i-heroicons-home-modern', description: 'Path to home ownership', color: 'bg-indigo-600' },
     { label: 'Income Strategy', to: '/menu/income', icon: 'i-heroicons-user-group', description: 'TMN, Salary, Household', color: 'bg-blue-500' },
     { label: 'Expense Categories', to: '/menu/categories', icon: 'i-heroicons-tag', description: 'Receipt categorization', color: 'bg-amber-500' },

--- a/test/unit/navigation.test.ts
+++ b/test/unit/navigation.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { useNavigation } from '~/composables/useNavigation'
+
+describe('useNavigation', () => {
+  it('includes Performance page in strategyItems', () => {
+    const { strategyItems } = useNavigation()
+    
+    const performanceItem = strategyItems.find(item => item.label === 'Performance')
+    
+    expect(performanceItem).toBeDefined()
+    expect(performanceItem?.to).toBe('/menu/performance')
+    expect(performanceItem?.icon).toBe('i-heroicons-presentation-chart-bar')
+  })
+
+  it('includes Performance page in navGroups', () => {
+    const { navGroups } = useNavigation()
+    
+    const moneyStrategyGroup = navGroups.find(group => group.label === 'Money & Strategy')
+    expect(moneyStrategyGroup).toBeDefined()
+    
+    const performanceItem = moneyStrategyGroup?.items.find(item => item.label === 'Performance')
+    expect(performanceItem).toBeDefined()
+    expect(performanceItem?.to).toBe('/menu/performance')
+  })
+
+  it('includes Performance page in allMenuItems', () => {
+    const { allMenuItems } = useNavigation()
+    
+    const performanceItem = allMenuItems.find(item => item.label === 'Performance')
+    expect(performanceItem).toBeDefined()
+    expect(performanceItem?.to).toBe('/menu/performance')
+  })
+})


### PR DESCRIPTION
Closes #90

## Agent Information
- **Implemented by**: ralph-dev-sonnet-4.5
- **Review status**: ✅ Approved
- **Reviewed by**: ralph-dev-minimax-m2.1
- **Reviewed at**: 2026-01-07T07:57:02.456Z

## Acceptance Criteria
- [x] Performance page linked in sidebar
- [x] Performance page linked in menu