### PR TITLE
Epic #89: Auto-repair expenses stuck in processing state

### DIFF
--- a/server/api/expenses/cron/repair-stuck.post.ts
+++ b/server/api/expenses/cron/repair-stuck.post.ts
@@ -1,0 +1,174 @@
+import { db } from 'hub:db'
+import { expenses, activityLog } from '~~/server/db/schema'
+import { eq, lt, and, sql } from 'drizzle-orm'
+import { extractReceiptData } from '~~/server/utils/gemini'
+import { createExpenseIfNotDuplicate } from '~~/server/utils/expenses'
+import { broadcastExpensesChanged } from '~~/server/utils/broadcast'
+import { blob } from 'hub:blob'
+import { extractText, getDocumentProxy } from 'unpdf'
+
+const TEN_MINUTES_AGO = new Date(Date.now() - 10 * 60 * 1000)
+
+export default defineEventHandler(async (event) => {
+  // Only allow cron authentication
+  const authHeader = getHeader(event, 'authorization')
+  const cronSecret = process.env.CRON_SECRET
+  
+  if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+
+  const results = {
+    checked: 0,
+    repaired: 0,
+    failed: 0,
+    skipped: 0
+  }
+
+  try {
+    // Find expenses stuck in 'processing' status for more than 10 minutes
+    const stuckExpenses = await db.select()
+      .from(expenses)
+      .where(and(
+        eq(expenses.status, 'processing'),
+        lt(expenses.updatedAt, TEN_MINUTES_AGO)
+      ))
+      .limit(50)
+
+    results.checked = stuckExpenses.length
+
+    for (const expense of stuckExpenses) {
+      const maxRetries = 3
+      const currentRetries = expense.retryCount ?? 0
+
+      if (currentRetries >= maxRetries) {
+        // Mark as error after max retries
+        await db.update(expenses)
+          .set({ status: 'error', updatedAt: new Date() })
+          .where(eq(expenses.id, expense.id))
+        
+        await db.insert(activityLog).values({
+          id: crypto.randomUUID(),
+          type: 'system',
+          level: 'warn',
+          message: `Expense ${expense.id.slice(0, 8)} marked as error after ${maxRetries} repair attempts`,
+          expenseId: expense.id,
+          source: 'server',
+          createdAt: new Date()
+        })
+        
+        results.failed++
+        continue
+      }
+
+      try {
+        // Increment retry count
+        await db.update(expenses)
+          .set({ 
+            status: 'processing', 
+            retryCount: sql`${expenses.retryCount} + 1`,
+            updatedAt: new Date() 
+          })
+          .where(eq(expenses.id, expense.id))
+
+        // Re-process the expense (similar to [id]/process.post.ts)
+        const imageKey = expense.imageKey || ''
+        const isPdf = imageKey.toLowerCase().endsWith('.pdf')
+        
+        const blobData = await blob.get(imageKey)
+        if (!blobData) {
+          throw new Error('File not found in storage')
+        }
+        
+        const arrayBuffer = await blobData.arrayBuffer()
+        const buffer = Buffer.from(arrayBuffer)
+        const base64 = buffer.toString('base64')
+
+        let pdfText: string | undefined
+        if (isPdf) {
+          try {
+            const pdf = await getDocumentProxy(new Uint8Array(arrayBuffer))
+            const result = await extractText(pdf, { mergePages: true })
+            pdfText = result.text
+          } catch (e) {
+            console.error('PDF text extraction failed during repair:', e)
+          }
+        }
+
+        const extraction = await extractReceiptData(isPdf ? { text: pdfText } : { image: base64 })
+        
+        await createExpenseIfNotDuplicate({
+          id: expense.id,
+          imageKey,
+          imageHash: expense.imageHash,
+          merchant: extraction.merchant || 'Unknown',
+          date: extraction.date,
+          total: extraction.total,
+          currency: extraction.currency,
+          tax: extraction.tax,
+          items: extraction.items,
+          rawExtraction: extraction,
+          capturedAt: expense.capturedAt || new Date(),
+        })
+
+        // Log successful repair
+        await db.insert(activityLog).values({
+          id: crypto.randomUUID(),
+          type: 'system',
+          level: 'success',
+          message: `Expense ${expense.id.slice(0, 8)} repaired successfully (attempt ${currentRetries + 1})`,
+          expenseId: expense.id,
+          source: 'server',
+          metadata: JSON.stringify({ retryCount: currentRetries + 1, merchant: extraction.merchant }),
+          createdAt: new Date()
+        })
+
+        broadcastExpensesChanged('system')
+        
+        results.repaired++
+      } catch (repairErr) {
+        console.error('Repair error for expense', expense.id, repairErr)
+        
+        await db.insert(activityLog).values({
+          id: crypto.randomUUID(),
+          type: 'error',
+          level: 'error',
+          message: `Failed to repair expense ${expense.id.slice(0, 8)} (attempt ${currentRetries + 1})`,
+          expenseId: expense.id,
+          source: 'server',
+          metadata: JSON.stringify({ error: String(repairErr), retryCount: currentRetries + 1 }),
+          createdAt: new Date()
+        })
+        
+        results.failed++
+      }
+    }
+
+    // Log cron run summary
+    await db.insert(activityLog).values({
+      id: crypto.randomUUID(),
+      type: 'system',
+      level: results.failed > 0 ? 'warn' : 'info',
+      message: `Repair cron completed: ${results.checked} checked, ${results.repaired} repaired, ${results.failed} failed`,
+      source: 'server',
+      metadata: JSON.stringify(results),
+      createdAt: new Date()
+    })
+
+    return results
+  } catch (err) {
+    console.error('Repair cron error:', err)
+    
+    await db.insert(activityLog).values({
+      id: crypto.randomUUID(),
+      type: 'error',
+      level: 'error',
+      message: 'Repair cron failed',
+      source: 'server',
+      metadata: JSON.stringify({ error: String(err) }),
+      createdAt: new Date()
+    })
+    
+    throw createError({ statusCode: 500, statusMessage: 'Repair cron failed' })
+  }
+})

--- a/server/api/expenses/index.post.ts
+++ b/server/api/expenses/index.post.ts
@@ -150,7 +150,7 @@ export default defineEventHandler(async (event) => {
         }
       } catch (processErr) {
         console.error('AI Processing error:', processErr)
-        await db.update(expenses).set({ status: 'failed', updatedAt: new Date() }).where(eq(expenses.id, id))
+        await db.update(expenses).set({ status: 'error', updatedAt: new Date() }).where(eq(expenses.id, id))
         
         logActivity({
           type: 'error',

--- a/server/db/migrations/0005_iron_venom.sql
+++ b/server/db/migrations/0005_iron_venom.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `expenses` ADD COLUMN `retry_count` integer DEFAULT 0 NOT NULL;

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -26,6 +26,7 @@ export const expenses = sqliteTable('expenses', {
   exchangeRate: real('exchange_rate'),
   createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
   updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull(),
+  retryCount: integer('retry_count').notNull().default(0),
 })
 
 export const categories = sqliteTable('categories', {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -14,3 +14,6 @@ binding = "DB"
 database_name = "finance-db"
 database_id = "7b47755f-3dff-423b-ab15-c340431622be"
 migrations_dir = "server/db/migrations"
+
+[[triggers]]
+crons = ["0,15,30,45 * * * *"]


### PR DESCRIPTION
Closes #89

## Agent Information
- **Implemented by**: ralph-dev-minimax-m2.1
- **Review status**: ✅ Approved
- **Reviewed by**: ralph-dev-glm-4.7-free
- **Reviewed at**: 2026-01-07T07:52:15.812Z

## Acceptance Criteria
- [x] Fix bug: Replace `'failed'` with `'error'` in index.post.ts line 153
- [x] Create `/api/expenses/cron/repair-stuck` endpoint that:
- [x] Add `retryCount` field to expenses schema (default 0)
- [x] Add cron trigger `"* * * * *"" (15 min) to call repair endpoint
- [x] Log repair attempts to activity_log